### PR TITLE
Changes to setup.py for uploading to PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ OIPA/static-root/
 
 # pyenv
 .python-version
+
+# distutils
+dist
+*.egg-info

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include OIPA/requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,16 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
+from distutils.core import setup
+from setuptools import find_packages
 from pip.req import parse_requirements
 
 install_requirements = parse_requirements('OIPA/requirements.txt', session=False)
 requirements = [str(ir.req) for ir in install_requirements]
 
 setup(name='OIPA',
-      version='2.3.3',
-      author='Zimmerman & Zimmerman',
-      description="OIPA is an open-source framework that renders IATI compliant XML and \
-            related indicator #opendata into the OIPA datamodel for storage. \
-            This ETL approach provides I/O using the OIPA Tastypie RESTless API (soon DRF!) \
-            providing you with direct XML or JSON output. Does Django and MySQL. \
-            Codebase maintained by Zimmerman & Zimmerman in Amsterdam. http://www.oipa.nl/",
+      version='2.3.4',
+      author='Catalpa',
+      description='A fork of https://github.com/zimmerman-zimmerman/OIPA used at Catalpa.',
       url='https://github.com/catalpainternational/oipa',
       packages=find_packages('OIPA'),  # iati, etc
       package_dir={'': 'OIPA'},


### PR DESCRIPTION
https://pypi.python.org/pypi/OIPA
#### Benefits:
- The package is 100x smaller, 200kb instead of 20mb. That's because it doesn't include all the data backup JSONs.
- Use the pip cache to avoid downloading the same version multiple times.
- No need for `--process-dependency-links`

Create a username on PyPI, then I can add you to the package members and you can upload a new version with `python setup.py sdist upload`
